### PR TITLE
initial 0.6.25

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -12,6 +12,3 @@ if errorlevel 1 exit 1
 
 ninja install
 if errorlevel 1 exit 1
-
-ninja test
-if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.8.0" %}
+{% set version = "0.6.25" %}
 
 package:
   name: aws-c-http
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://github.com/awslabs/aws-c-http/archive/v{{ version }}.tar.gz
-  sha256: d0eae3d4b84f10c64ca4c9ba4b143745ad46532fdcac081f1cda90f1e956c98a
+  sha256: 8c4b4dcf49ef1abec48cfa6748983e352b490d557fa06e0565107c826d589fb0
 
 build:
-  number: 4
+  number: 0
   run_exports:
     - {{ pin_subpackage("aws-c-http", max_pin="x.x.x") }}
 
@@ -17,12 +17,12 @@ requirements:
   build:
     - cmake
     - {{ compiler('c') }}
-    - ninja
+    - ninja-base
   host:
-    - aws-c-cal
-    - aws-c-common
-    - aws-c-compression
-    - aws-c-io
+    - aws-c-cal 0.5.20
+    - aws-c-common 0.8.5
+    - aws-c-compression 0.2.16
+    - aws-c-io 0.13.10
 
 test:
   commands:
@@ -36,7 +36,12 @@ about:
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  summary: C99 implementation of the HTTP/1.1 and HTTP/2 specifications
+  summary: C99 implementation of the HTTP protocol
+  description: |
+    C99 implementation of the HTTP/1.1 and HTTP/2 specifications
+  doc_url: https://github.com/awslabs/aws-c-http
+  dev_url: https://github.com/awslabs/aws-c-http
+  
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
aws-c-http 0.6.25

Destination channel: defaults

Links
[{ticket_number}](https://anaconda.atlassian.net/browse/PKG-3945)
[Upstream repository](https://github.com/awslabs/aws-c-http/releases/tag/v0.6.25)
dependency for aws-sdk-cpp 1.10.55 -> arrow-cpp 14.0.1 -> pyarrow 14.0.1 which would address CVE