### PR TITLE
aws-c-http 0.9.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,5 @@ channels:
   - https://staging.continuum.io/prefect/fs/aws-c-cal-feedstock/pr2/071091c
   - https://staging.continuum.io/prefect/fs/aws-c-compression-feedstock/pr2/854701d
   - https://staging.continuum.io/prefect/fs/aws-c-io-feedstock/pr2/bf28bef
+  - https://staging.continuum.io/prefect/fs/aws-c-cal-feedstock/pr2/071091c
+  - https://staging.continuum.io/prefect/fs/s2n-feedstock/pr2/9f12ab9

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/aws-c-cal-feedstock/pr2/071091c
+  - https://staging.continuum.io/prefect/fs/aws-c-compression-feedstock/pr2/854701d
+  - https://staging.continuum.io/prefect/fs/aws-c-io-feedstock/pr2/bf28bef

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/aws-c-cal-feedstock/pr2/071091c
-  - https://staging.continuum.io/prefect/fs/aws-c-compression-feedstock/pr2/854701d
-  - https://staging.continuum.io/prefect/fs/aws-c-io-feedstock/pr2/bf28bef
-  - https://staging.continuum.io/prefect/fs/aws-c-cal-feedstock/pr2/071091c
-  - https://staging.continuum.io/prefect/fs/s2n-feedstock/pr2/9f12ab9

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,10 +19,10 @@ requirements:
     - {{ compiler('c') }}
     - ninja-base
   host:
-    - aws-c-cal 0.5.20
-    - aws-c-common 0.8.5
-    - aws-c-compression 0.2.16
-    - aws-c-io 0.13.10
+    - aws-c-cal 0.8.5
+    - aws-c-common 0.11.1
+    - aws-c-compression 0.3.1
+    - aws-c-io 0.17.0
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.6.25" %}
+{% set version = "0.9.3" %}
 
 package:
   name: aws-c-http
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/awslabs/aws-c-http/archive/v{{ version }}.tar.gz
-  sha256: 8c4b4dcf49ef1abec48cfa6748983e352b490d557fa06e0565107c826d589fb0
+  sha256: 63061321fd3234a4f8688cff1a6681089321519436a5f181e1bcb359204df7c8
 
 build:
   number: 0
@@ -41,7 +41,7 @@ about:
     C99 implementation of the HTTP/1.1 and HTTP/2 specifications
   doc_url: https://github.com/awslabs/aws-c-http
   dev_url: https://github.com/awslabs/aws-c-http
-  
+
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-7285](https://anaconda.atlassian.net/browse/PKG-7285)
- [Upstream repository](https://github.com/awslabs/aws-c-http/tree/v0.9.3)


### Explanation of changes:

- Update version
- Update dependencies


[PKG-7285]: https://anaconda.atlassian.net/browse/PKG-7285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ