### PR TITLE
aws-c-http 0.9.3 rebuild

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,14 +1,19 @@
 mkdir "%SRC_DIR%"\build
 pushd "%SRC_DIR%"\build
 
-cmake -G "Ninja" ^
+cmake -GNinja ^
       -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
       -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
       -DCMAKE_INSTALL_LIBDIR=lib ^
       -DCMAKE_BUILD_TYPE=Release ^
       -DBUILD_SHARED_LIBS=ON ^
+      -DENABLE_TESTING=ON ^
+      -DCMAKE_POSITION_INDEPENDENT_CODE=ON ^
       ..
 if errorlevel 1 exit 1
 
-ninja install
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1
+
+ctest --output-on-failure
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,9 +10,21 @@ cmake ${CMAKE_ARGS} -GNinja \
   -DCMAKE_INSTALL_LIBDIR=lib \
   -DCMAKE_BUILD_TYPE=Release \
   -DBUILD_SHARED_LIBS=ON \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+  -DENABLE_TESTING=ON \
   ..
-ninja install
-#if [[ "${CONDA_BUILD_CROSS_COMPILATION:-0}" != "1" ]]; then
-#  ctest -E tls_download_medium_file_h2
-#fi
+
+cmake --build . --config Release --target install
+
+if [[ ${target_platform} == osx-* ]]; then
+  # Following tests require root privileges (may prompt for root password).
+  EXCLUDE_ROOT_TESTS_APPLE="\
+connection_setup_shutdown_tls|\
+connection_customized_alpn|\
+connection_customized_alpn_error_with_unknown_return_string"
+
+  ctest -E "$EXCLUDE_ROOT_TESTS_APPLE" --output-on-failure -j${CPU_COUNT}
+else
+  ctest --output-on-failure -j${CPU_COUNT}
+fi
 popd

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,7 +21,8 @@ if [[ ${target_platform} == osx-* ]]; then
   EXCLUDE_ROOT_TESTS_APPLE="\
 connection_setup_shutdown_tls|\
 connection_customized_alpn|\
-connection_customized_alpn_error_with_unknown_return_string"
+connection_customized_alpn_error_with_unknown_return_string|\
+connection_h2_prior_knowledge_not_work_with_tls"
 
   ctest -E "$EXCLUDE_ROOT_TESTS_APPLE" --output-on-failure -j${CPU_COUNT}
 else

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 63061321fd3234a4f8688cff1a6681089321519436a5f181e1bcb359204df7c8
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("aws-c-http", max_pin="x.x.x") }}
 
@@ -19,8 +19,8 @@ requirements:
     - {{ compiler('c') }}
     - ninja-base
   host:
-    - aws-c-cal 0.8.5
-    - aws-c-common 0.11.1
+    - aws-c-cal 0.9.2
+    - aws-c-common 0.12.3
     - aws-c-compression 0.3.1
     - aws-c-io 0.17.0
 


### PR DESCRIPTION
aws-c-http 0.9.3 rebuild

**Destination channel:** Defaults

### Links

- [PKG-8592]
- dev_url:        https://github.com/awslabs/aws-c-http/tree/v0.9.3
- conda_forge:    https://github.com/conda-forge/aws-c-http-feedstock
- pypi:           https://pypi.org/project/aws-c-http/0.9.3
- pypi inspector: https://inspector.pypi.io/project/aws-c-http/0.9.3/

### Explanation of changes:

- rebuild due to new dependency version


[PKG-8592]: https://anaconda.atlassian.net/browse/PKG-8592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ