### PR TITLE
aws-c-http 0.10.2 

### DIFF
--- a/recipe/abs.yaml
+++ b/recipe/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/aws-c-io-feedstock/pr4/d06c21e

--- a/recipe/abs.yaml
+++ b/recipe/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/aws-c-io-feedstock/pr4/d06c21e

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,7 +7,7 @@ cmake -GNinja ^
       -DCMAKE_INSTALL_LIBDIR=lib ^
       -DCMAKE_BUILD_TYPE=Release ^
       -DBUILD_SHARED_LIBS=ON ^
-      -DENABLE_TESTING=ON ^
+      -DBUILD_TESTING=ON ^
       -DCMAKE_POSITION_INDEPENDENT_CODE=ON ^
       ..
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,7 +11,7 @@ cmake ${CMAKE_ARGS} -GNinja \
   -DCMAKE_BUILD_TYPE=Release \
   -DBUILD_SHARED_LIBS=ON \
   -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-  -DENABLE_TESTING=ON \
+  -DBUILD_TESTING=ON \
   ..
 
 cmake --build . --config Release --target install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,12 @@
+{% set name = "aws-c-http" %}
 {% set version = "0.10.2" %}
 
 package:
-  name: aws-c-http
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/awslabs/aws-c-http/archive/v{{ version }}.tar.gz
+  url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
   sha256: 048d9d683459ade363fd7cc448c2b6329c78f67a2a0c0cb61c16de4634a2fc6b
 
 build:
@@ -15,7 +16,7 @@ build:
 
 requirements:
   build:
-    - cmake
+    - cmake >=3.9
     - {{ compiler('c') }}
     - ninja-base
   host:
@@ -41,7 +42,6 @@ about:
     C99 implementation of the HTTP/1.1 and HTTP/2 specifications
   doc_url: https://github.com/awslabs/aws-c-http
   dev_url: https://github.com/awslabs/aws-c-http
-
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.9.3" %}
+{% set version = "0.10.2" %}
 
 package:
   name: aws-c-http
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://github.com/awslabs/aws-c-http/archive/v{{ version }}.tar.gz
-  sha256: 63061321fd3234a4f8688cff1a6681089321519436a5f181e1bcb359204df7c8
+  sha256: 048d9d683459ade363fd7cc448c2b6329c78f67a2a0c0cb61c16de4634a2fc6b
 
 build:
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage("aws-c-http", max_pin="x.x.x") }}
 
@@ -22,7 +22,7 @@ requirements:
     - aws-c-cal 0.9.2
     - aws-c-common 0.12.3
     - aws-c-compression 0.3.1
-    - aws-c-io 0.17.0
+    - aws-c-io 0.20.1
 
 test:
   commands:


### PR DESCRIPTION
aws-c-http 0.10.2 

**Destination channel:** Defaults

### Links

- [PKG-8666]
- dev_url:        https://github.com/awslabs/aws-c-http/tree/v0.10.2
- conda_forge:    https://github.com/conda-forge/aws-c-http-feedstock
- pypi:           https://pypi.org/project/aws-c-http/0.10.2
- pypi inspector: https://inspector.pypi.io/project/aws-c-http/0.10.2/

### Explanation of changes:

- new version number


[PKG-8666]: https://anaconda.atlassian.net/browse/PKG-8666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ