### PR TITLE
Update version to 0.10.7

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -15,5 +15,11 @@ if errorlevel 1 exit 1
 cmake --build . --config Release --target install
 if errorlevel 1 exit 1
 
-ctest --output-on-failure
+set "EXCLUDE_ROOT_TESTS=^
+connection_setup_shutdown_tls|^
+connection_customized_alpn|^
+connection_customized_alpn_error_with_unknown_return_string|^
+connection_manager_single_http2_connection_failed"
+
+ctest -E "%EXCLUDE_ROOT_TESTS%" --output-on-failure
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -15,11 +15,7 @@ if errorlevel 1 exit 1
 cmake --build . --config Release --target install
 if errorlevel 1 exit 1
 
-set "EXCLUDE_ROOT_TESTS=^
-connection_setup_shutdown_tls|^
-connection_customized_alpn|^
-connection_customized_alpn_error_with_unknown_return_string|^
-connection_manager_single_http2_connection_failed"
+set "EXCLUDE_ROOT_TESTS=connection_setup_shutdown_tls|connection_customized_alpn|connection_customized_alpn_error_with_unknown_return_string|connection_manager_single_http2_connection_failed"
 
 ctest -E "%EXCLUDE_ROOT_TESTS%" --output-on-failure
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,17 +16,12 @@ cmake ${CMAKE_ARGS} -GNinja \
 
 cmake --build . --config Release --target install
 
-if [[ ${target_platform} == osx-* ]]; then
-  # Following tests require root privileges (may prompt for root password).
-  EXCLUDE_ROOT_TESTS_APPLE="\
+# Following tests failed with error Certificate has expired 
+  EXCLUDE_ROOT_TESTS="\
 connection_setup_shutdown_tls|\
 connection_customized_alpn|\
 connection_customized_alpn_error_with_unknown_return_string|\
-connection_manager_single_http2_connection_failed|\
-connection_h2_prior_knowledge_not_work_with_tls"
+connection_manager_single_http2_connection_failed"
 
-  ctest -E "$EXCLUDE_ROOT_TESTS_APPLE" --output-on-failure -j${CPU_COUNT}
-else
-  ctest --output-on-failure -j${CPU_COUNT}
-fi
+  ctest -E "$EXCLUDE_ROOT_TESTS" --output-on-failure -j${CPU_COUNT}
 popd

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,6 +20,7 @@ cmake --build . --config Release --target install
   EXCLUDE_ROOT_TESTS="\
 connection_setup_shutdown_tls|\
 connection_customized_alpn|\
+connection_h2_prior_knowledge_not_work_with_tls|\
 connection_customized_alpn_error_with_unknown_return_string|\
 connection_manager_single_http2_connection_failed"
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,6 +22,7 @@ if [[ ${target_platform} == osx-* ]]; then
 connection_setup_shutdown_tls|\
 connection_customized_alpn|\
 connection_customized_alpn_error_with_unknown_return_string|\
+connection_manager_single_http2_connection_failed|\
 connection_h2_prior_knowledge_not_work_with_tls"
 
   ctest -E "$EXCLUDE_ROOT_TESTS_APPLE" --output-on-failure -j${CPU_COUNT}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-c-http" %}
-{% set version = "0.10.4" %}
+{% set version = "0.10.7" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: dfeeeaa2e84ccda4c8cb0c29f412298df80a57a27003e716f2d3df9794956fc1
+  sha256: ce9e71c3eae67b1c6c0149278e0d0929a7d928c3547de64999430c8592864ad4
 
 build:
   number: 0
@@ -21,10 +21,10 @@ requirements:
     - cmake >=3.9
     - ninja-base
   host:
-    - aws-c-cal 0.9.2
-    - aws-c-common 0.12.4
+    - aws-c-cal 0.9.13
+    - aws-c-common 0.12.6
     - aws-c-compression 0.3.1
-    - aws-c-io 0.21.4
+    - aws-c-io 0.23.3
 
 test:
   commands:


### PR DESCRIPTION
aws-c-http 0.10.7

**Destination channel:** defaults

### Links

- [PKG-11432](https://anaconda.atlassian.net/browse/PKG-11432) 
- [Upstream repository](https://github.com/awslabs/aws-c-http/tree/v0.10.7)

### Explanation of changes:

- New version number
- updated dependencies
- updated list of ignored tests


[PKG-11432]: https://anaconda.atlassian.net/browse/PKG-11432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ