### PR TITLE
aws-c-http 0.10.13 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channel:
+  - https://staging.continuum.io/preprod-pbp/fs/aws-c-io-feedstock/pr7/928beff
+  - https://staging.continuum.io/preprod-pbp/fs/aws-c-compression-feedstock/pr6/8a902d3

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,3 @@
-channel:
+channels:
   - https://staging.continuum.io/preprod-pbp/fs/aws-c-io-feedstock/pr7/928beff
   - https://staging.continuum.io/preprod-pbp/fs/aws-c-compression-feedstock/pr6/8a902d3

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/preprod-pbp/fs/aws-c-io-feedstock/pr7/928beff
-  - https://staging.continuum.io/preprod-pbp/fs/aws-c-compression-feedstock/pr6/8a902d3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,8 @@ requirements:
   host:
     - aws-c-cal 0.9.13
     - aws-c-common 0.12.6
-    - aws-c-compression 0.3.1
-    - aws-c-io 0.23.3
+    - aws-c-compression 0.3.2
+    - aws-c-io 0.26.3
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-c-http" %}
-{% set version = "0.10.7" %}
+{% set version = "0.10.13" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: ce9e71c3eae67b1c6c0149278e0d0929a7d928c3547de64999430c8592864ad4
+  sha256: d8352e7a1fb1996694a4dc31219ce03452882abf8d0858c104727f975e11b9c7
 
 build:
   number: 0


### PR DESCRIPTION
aws-c-http 0.10.13 

**Destination channel:** Defaults

### Links

- [PKG-13595]
- dev_url:        https://github.com/awslabs/aws-c-http
- conda_forge:    https://github.com/conda-forge/aws-c-http-feedstock
- pypi:           https://pypi.org/project/aws-c-http/0.10.13
- pypi inspector: https://inspector.pypi.io/project/aws-c-http/0.10.13

### Explanation of changes:

- new version number


[PKG-13595]: https://anaconda.atlassian.net/browse/PKG-13595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ