### PR TITLE
aws-c-http 0.11.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-c-http" %}
-{% set version = "0.10.13" %}
+{% set version = "0.11.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: d8352e7a1fb1996694a4dc31219ce03452882abf8d0858c104727f975e11b9c7
+  sha256: 4ccbdd33c798b590288330dec9e93abe2ff6cfb198b7a4db036c9d362f2e6506
 
 build:
   number: 0


### PR DESCRIPTION
aws-c-http 0.11.0 

**Destination channel:** Defaults

### Links

- [PKG-15437]
- dev_url:        https://github.com/awslabs/aws-c-http/tree/v0.11.0
- conda_forge:    https://github.com/conda-forge/aws-c-http-feedstock
- pypi:           None
- pypi inspector: None

### Explanation of changes:

- new version number


[PKG-15437]: https://anaconda.atlassian.net/browse/PKG-15437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ